### PR TITLE
Update release date for version 3.9.5 and adjust commit reference in YAML configuration

### DIFF
--- a/io.github.tlcfem.suanPan.metainfo.xml
+++ b/io.github.tlcfem.suanPan.metainfo.xml
@@ -26,7 +26,7 @@
       <binary>suanPan</binary>
    </provides>
    <releases>
-      <release version="3.9.5" date="2025-11-11" />
+      <release version="3.9.5" date="2025-12-09" />
       <release version="3.9.4" date="2025-11-11" />
       <release version="3.9.3" date="2025-10-15" />
       <release version="3.9.2" date="2025-09-23" />

--- a/io.github.tlcfem.suanPan.yml
+++ b/io.github.tlcfem.suanPan.yml
@@ -34,7 +34,7 @@ modules:
     sources:
       - type: git
         url: 'https://github.com/TLCFEM/suanPan.git'
-        commit: 1ec2cfe3d62f04e405994b42bc2693c4a8708172
+        commit: 799e8ff7ab7e8de9ae7fe3b5a0078b7d9b2754b2
       - type: file
         path: io.github.tlcfem.suanPan.metainfo.xml
       - type: file


### PR DESCRIPTION
Update the release date for version 3.9.5 to December 9, 2025, and modify the commit reference in the YAML configuration accordingly.