### PR TITLE
Add commit reference for suanPan module in YAML configuration

### DIFF
--- a/io.github.tlcfem.suanPan.yml
+++ b/io.github.tlcfem.suanPan.yml
@@ -36,6 +36,7 @@ modules:
       - type: git
         url: https://github.com/TLCFEM/suanPan.git
         tag: suanPan-v4.1
+        commit: 0d177edc241a06bced166e6faf6b792c7fb6d387
       - type: file
         path: io.github.tlcfem.suanPan.metainfo.xml
       - type: file


### PR DESCRIPTION
Include a specific commit reference for the suanPan module in the YAML configuration to ensure consistency and reliability in module usage.